### PR TITLE
feat: Add edit and update functionality for Learnings

### DIFF
--- a/app/controllers/learnings_controller.rb
+++ b/app/controllers/learnings_controller.rb
@@ -25,6 +25,21 @@ class LearningsController < ApplicationController
     end
   end
 
+  # GET /learnings/1/edit
+  def edit
+    @learning = Learning.find(params[:id])
+  end
+
+  # PATCH/PUT /learnings/1
+  def update
+    @learning = Learning.find(params[:id])
+    if @learning.update(learning_params)
+      redirect_to learnings_path, notice: "Learning updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   def destroy_multiple
     learnings_to_delete = Learning.where(id: params[:learning_ids])
     deleted_count = learnings_to_delete.count

--- a/app/views/learnings/_form.html.erb
+++ b/app/views/learnings/_form.html.erb
@@ -1,0 +1,38 @@
+<%= form_with(model: learning) do |form| %>
+  <% if learning.errors.any? %>
+    <div class="form-errors">
+      <h2><%= pluralize(learning.errors.count, "error") %> prohibited this learning from being saved:</h2>
+      <ul>
+        <% learning.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :title %><br>
+    <%= form.text_field :title %>
+  </div>
+
+  <div>
+    <%= form.label :body %><br>
+    <%= form.text_area :body, rows: 5 %>
+  </div>
+
+  <div>
+    <%= form.label :learned_on, "Learned On" %><br>
+    <%# Reason: Use existing date if available (editing), otherwise default to today (new) %>
+    <%= form.date_field :learned_on, value: (learning.learned_on || Date.today) %>
+  </div>
+
+  <div>
+    <%= form.label :tags, "Tags (comma-separated)" %><br>
+    <%= form.text_field :tags %>
+  </div>
+
+  <div>
+    <%# Reason: Change button text based on whether the record is persisted %>
+    <%= form.submit (learning.persisted? ? "Update Learning" : "Log Learning") %>
+  </div>
+<% end %>

--- a/app/views/learnings/edit.html.erb
+++ b/app/views/learnings/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>Edit Learning</h1>
+
+<%= render 'form', learning: @learning %>
+
+<%= link_to 'Back to Learnings', learnings_path %>

--- a/app/views/learnings/index.html.erb
+++ b/app/views/learnings/index.html.erb
@@ -52,6 +52,8 @@
                 </div>
               <% end %>
               <small>Learned on: <%= learning.learned_on.strftime("%B %d, %Y") %></small>
+              <%# Reason: Add Edit link alongside date %>
+              <small><%= link_to "Edit", edit_learning_path(learning) %></small>
             </div>
           </label>
         <% end %>

--- a/app/views/learnings/new.html.erb
+++ b/app/views/learnings/new.html.erb
@@ -1,38 +1,3 @@
 <h1>Log a New Learning</h1>
 
-<%= form_with(model: @learning, url: learnings_path, method: :post) do |form| %>
-  <% if @learning.errors.any? %>
-    <div class="form-errors">
-      <h2><%= pluralize(@learning.errors.count, "error") %> prohibited this learning from being saved:</h2>
-      <ul>
-        <% @learning.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div>
-    <%= form.label :title %><br>
-    <%= form.text_field :title %>
-  </div>
-
-  <div>
-    <%= form.label :body %><br>
-    <%= form.text_area :body, rows: 5 %>
-  </div>
-
-  <div>
-    <%= form.label :learned_on, "Learned On" %><br>
-    <%= form.date_field :learned_on, value: Date.today %>
-  </div>
-
-  <div>
-    <%= form.label :tags, "Tags (comma-separated)" %><br>
-    <%= form.text_field :tags %>
-  </div>
-
-  <div>
-    <%= form.submit "Log Learning" %>
-  </div>
-<% end %>
+<%= render 'form', learning: @learning %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
   get "hire-me", to: "static_pages#hire_me"
   get "about", to: "static_pages#about"
 
-  # Learning Resources (only index, new, create)
-  resources :learnings, only: [ :index, :new, :create ] do
+  # Learning Resources (now including edit/update)
+  resources :learnings, only: [ :index, :new, :create, :edit, :update ] do
     delete :destroy_multiple, on: :collection
   end
 

--- a/spec/requests/learnings_spec.rb
+++ b/spec/requests/learnings_spec.rb
@@ -89,6 +89,55 @@ RSpec.describe "Learnings", type: :request do
     end
   end
 
+  describe "GET /learnings/:id/edit" do
+    it "returns http success" do
+      get edit_learning_path(learning1)
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Edit Learning")
+      expect(response.body).to include(learning1.title)
+    end
+  end
+
+  describe "PATCH /learnings/:id" do
+    context "with valid parameters" do
+      let(:new_attributes) {
+        { title: "Updated Ruby Basics", body: "Updated body", tags: "ruby, updated", learned_on: Date.today - 3.days }
+      }
+
+      it "updates the requested learning" do
+        patch learning_path(learning1), params: { learning: new_attributes }
+        learning1.reload
+        expect(learning1.title).to eq("Updated Ruby Basics")
+        expect(learning1.body).to eq("Updated body")
+        expect(learning1.tags).to eq("ruby, updated")
+        expect(learning1.learned_on).to eq(Date.today - 3.days)
+      end
+
+      it "redirects to the learnings index" do
+        patch learning_path(learning1), params: { learning: new_attributes }
+        expect(response).to redirect_to(learnings_path)
+        expect(flash[:notice]).to eq("Learning updated successfully.")
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:invalid_attributes) { { title: "", body: "" } } # Invalid: missing title and body
+
+      it "does not update the learning" do
+        original_title = learning1.title
+        patch learning_path(learning1), params: { learning: invalid_attributes }
+        learning1.reload
+        expect(learning1.title).to eq(original_title)
+      end
+
+      it "re-renders the 'edit' template" do
+        patch learning_path(learning1), params: { learning: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
   describe "DELETE /learnings/multiple" do
     it "deletes the selected learnings" do
       learnings_to_delete = [ learning1, learning3 ]


### PR DESCRIPTION
- Implemented edit and update actions in LearningsController to allow users to modify existing learnings.
- Updated routes to include edit and update actions for learnings.
- Enhanced the index view to include an "Edit" link for each learning entry.
- Refactored the new learning form into a partial for reuse in the edit view.
- Added request specs to ensure proper functionality of the edit and update actions, including validation for both valid and invalid parameters.