### PR TITLE
docs: Update README and About page with deployment details 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This is a simple "Today I Learned" (TIL) tracker application built with Ruby on 
 
 It also serves as a self-referential job application, demonstrating core Rails skills.
 
+## Deployment
+
+This application is deployed on Render.
+
+**Live URL:** [https://til-tracker.onrender.com/](https://til-tracker.onrender.com/)
+
 ## Ruby Version
 
 - Ruby 3.2.2 (Managed via `rbenv`)
@@ -65,11 +71,3 @@ It also serves as a self-referential job application, demonstrating core Rails s
 - **No CSS Framework:** Uses simple, hand-crafted CSS (`app/assets/stylesheets/application.css`).
 - **Simple Tagging:** Uses a basic string field for tags to maintain simplicity.
 - **No Authentication:** Focuses on core CRUD functionality.
-
-## Deployment
-
-This application is deployed on Render.
-
-**Live URL:** [https://til-tracker.onrender.com/](https://til-tracker.onrender.com/)
-
-*(Note: The free tier may cause the application to spin down after inactivity, resulting in a short delay on the first visit.)*

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -1,4 +1,40 @@
-<h1>About This App</h1>
-<p>This application is a simple 'Today I Learned' (TIL) tracker.</p>
-<p>It's built with Ruby on Rails and serves as a demonstration of core web development skills.</p>
-<p>Feel free to browse the learnings or add your own!</p>
+<h1>About This TIL Tracker</h1>
+
+<p>
+  This application is a simple "Today I Learned" (TIL) tracker, built as part of my application for the
+  <strong>Junior Rails Programmer</strong> role at 37signals.
+</p>
+
+<p>
+  Its primary purpose is to demonstrate practical skills in Ruby on Rails development, following the principles
+  and practices valued by 37signals. This includes:
+</p>
+
+<ul>
+  <li><strong>Standard Rails:</strong> Built on Ruby on Rails 7+, adhering to conventions and keeping things simple.</li>
+  <li><strong>Hotwire for Interactivity:</strong> Features like tag filtering rely on Turbo Frames for efficient updates without complex JavaScript.</li>
+  <li><strong>Hand-crafted CSS:</strong> All styling is done with plain, semantic CSS, avoiding frameworks like Tailwind or Bootstrap. The focus is on clarity and usability.</li>
+  <li><strong>Simplicity:</strong> The application avoids unnecessary layers or dependencies, focusing on core functionality.</li>
+</ul>
+
+<h2>Features</h2>
+<ul>
+  <li>Log new learnings with a title, detailed body, and relevant tags.</li>
+  <li>Assign a specific date to each learning, allowing for retroactive logging.</li>
+  <li>View all learnings, sorted by the date learned.</li>
+  <li>Edit existing learnings.</li>
+  <li>Filter learnings by clicking on tags.</li>
+  <li>Select and delete multiple learnings at once.</li>
+</ul>
+
+<h2>Notes</h2>
+
+<p>
+  It is my first Rails application. Partly, I built it to learn Rails, but also to have a simple tool to log my learnings and share them with you. This app represents an effort to build a useful tool while showcasing craftsmanship and a thoughtful approach to web development.
+</p>
+<p>
+  The development process itself, including challenges faced and decisions made, is documented separately. The <a href="https://github.com/danieldanilov/til_tracker">github repository is here</a>. The app runs on <a href="https://render.com/">Render</a>.
+</p>
+<p>
+  The learnings are real: they were tracked separately in a markdown file, which were later uploaded to the app via <a href="https://github.com/danieldanilov/til_tracker/blob/main/db/seeds.rb">seeds.rb</a>. This also ensures that the learnings are retroactively logged and that you are able to view them in the order they were learned.
+</p>


### PR DESCRIPTION
- Added deployment section to README with live URL on Render (and moved it up so it's easier to find).
- Revised About page to provide a clearer overview of the application, its purpose, features, and development process.
- Emphasized the application's role as a demonstration of Ruby on Rails skills for a job application.